### PR TITLE
ontology-ontology xrefs can be many-to-many

### DIFF
--- a/data_dictionary/cross_reference.yaml
+++ b/data_dictionary/cross_reference.yaml
@@ -38,7 +38,7 @@ relations:
   - relatedNode: Ontology
     backref: cross_reference
     label: cross_reference
-    multiplicity: many_to_one
+    multiplicity: many_to_many
     required: false
   - relatedNode: Gene
     backref: cross_reference


### PR DESCRIPTION
I may misunderstand the spec but I think this should be many to many. Nice xrefs are 1:1, but there are no guarantees. E.g. many DO xrefs are many to many