### PR TITLE
Changes to HTP metadata schema

### DIFF
--- a/ingest/htp/dataset/datasetAnnotation.json
+++ b/ingest/htp/dataset/datasetAnnotation.json
@@ -15,7 +15,7 @@
             "$ref": "../htpId.json#",
             "description": "An id associated with a dataset object; these will external or MOD IDs."
         },
-        "publication": {
+        "publications": {
             "type": "array",
             "items": {
                 "$ref": "../../publicationRef.json#"

--- a/ingest/htp/dataset/datasetAnnotation.json
+++ b/ingest/htp/dataset/datasetAnnotation.json
@@ -7,7 +7,8 @@
     "required": [
         "dateAssigned",
         "title",
-        "datasetId"
+        "datasetId",
+	"categoryTags"
     ],
     "additionalProperties": false,
     "properties": {

--- a/ingest/htp/dataset/exampleDataset.json
+++ b/ingest/htp/dataset/exampleDataset.json
@@ -4,7 +4,7 @@
       "datasetId": {
         "primaryId": "GEO:GSE19302"
       },
-      "publication": [
+      "publications": [
         {
           "publicationId": "PMID:21680710"
         }

--- a/ingest/htp/dataset/exampleSuperseriesDataset.json
+++ b/ingest/htp/dataset/exampleSuperseriesDataset.json
@@ -4,7 +4,7 @@
       "datasetId": {
         "primaryId": "GEO:GSE144901"
       },
-      "publication": [
+      "publications": [
         {
           "publicationId": "PMID:22265871",
           "crossReference": {

--- a/ingest/htp/dataset/exampleSuperseriesDataset.json
+++ b/ingest/htp/dataset/exampleSuperseriesDataset.json
@@ -24,7 +24,8 @@
         "GEO:GSE144894",
         "GEO:GSE144896"
       ],
-      "dateAssigned": "2020-05-06T20:05:44-00:00"
+      "dateAssigned": "2020-05-06T20:05:44-00:00",
+      "categoryTags":["unclassified"]
     }
   ],
   "metaData": {

--- a/ingest/htp/datasetSample/datasetSampleAnnotation.json
+++ b/ingest/htp/datasetSample/datasetSampleAnnotation.json
@@ -36,7 +36,7 @@
             }
         },
         "genomicInformation": {
-            "$ref": "bioSampleGenomicInformation.json#",
+            "$ref": "../bioSampleGenomicInformation.json#",
             "description": "A collection of information that represents the strain or genomic background of the sample, either an id or free text"
         },
         "taxonId": {

--- a/ingest/htp/datasetSample/datasetSampleAnnotation.json
+++ b/ingest/htp/datasetSample/datasetSampleAnnotation.json
@@ -86,7 +86,7 @@
             "description": "Date this entity was assigned/curated by a MOD."
         }
     },
-    "anyOf": [{"required": ["sampleId","datasetId"]},
-              {"required": ["sampleTitle","datasetId"]}
+    "anyOf": [{"required": ["sampleId","datasetId","sampleType","assayType"]},
+              {"required": ["sampleTitle","datasetId","sampleType","assayType"]}
              ]
 }

--- a/ingest/htp/datasetSample/datasetSampleAnnotation.json
+++ b/ingest/htp/datasetSample/datasetSampleAnnotation.json
@@ -86,7 +86,7 @@
             "description": "Date this entity was assigned/curated by a MOD."
         }
     },
-    "anyOf": [{"required": ["sampleId","datasetIds","sampleType","assayType"]},
-              {"required": ["sampleTitle","datasetIds","sampleType","assayType"]}
+    "anyOf": [{"required": ["sampleId","datasetIds","assayType"]},
+              {"required": ["sampleTitle","datasetIds","assayType"]}
              ]
 }

--- a/ingest/htp/datasetSample/datasetSampleAnnotation.json
+++ b/ingest/htp/datasetSample/datasetSampleAnnotation.json
@@ -86,7 +86,7 @@
             "description": "Date this entity was assigned/curated by a MOD."
         }
     },
-    "anyOf": [{"required": ["sampleId","datasetId","sampleType","assayType"]},
-              {"required": ["sampleTitle","datasetId","sampleType","assayType"]}
+    "anyOf": [{"required": ["sampleId","datasetIds","sampleType","assayType"]},
+              {"required": ["sampleTitle","datasetIds","sampleType","assayType"]}
              ]
 }

--- a/ingest/htp/datasetSample/datasetSampleAnnotation.json
+++ b/ingest/htp/datasetSample/datasetSampleAnnotation.json
@@ -86,7 +86,7 @@
             "description": "Date this entity was assigned/curated by a MOD."
         }
     },
-    "anyOf": [{"required": ["sampleId","datasetIds","assayType"]},
-              {"required": ["sampleTitle","datasetIds","assayType"]}
+    "anyOf": [{"required": ["sampleId","datasetIds","assayType", "sampleType"]},
+              {"required": ["sampleTitle","datasetIds","assayType","sampleType"]}
              ]
 }

--- a/ingest/htp/datasetSample/datasetSampleAnnotation.json
+++ b/ingest/htp/datasetSample/datasetSampleAnnotation.json
@@ -28,7 +28,7 @@
             "$ref": "biosampleAge.json#",
             "description": "a collection of terms that when used together represent the age and stage of the sample"
         },
-        "sampleLocation": {
+        "sampleLocations": {
             "type":"array",
             "items": {
                 "$ref": "../../expression/whereExpressed.json#",
@@ -58,7 +58,7 @@
             "enum": ["single","paired"],
             "description": "single or paired end sequencing; might be better in experiment info"
         },
-        "assemblyVersion": {
+        "assemblyVersions": {
             "type":"array",
             "items": {
                 "type": "string"
@@ -69,7 +69,7 @@
             "type": "string",
             "description": "curated notes about the sample"
         },
-        "datasetId": {
+        "datasetIds": {
             "type": "array",
             "items": {
                     "$ref": "../../globalId.json#/properties/globalId"

--- a/ingest/htp/datasetSample/exampleSGDdatasample.json
+++ b/ingest/htp/datasetSample/exampleSGDdatasample.json
@@ -8,7 +8,7 @@
                         "sampleType": "OBI:0000895",
                         "taxonId": "NCBITaxon:4932",
                         "assayType": "MMO:0000649",
-                        "datasetId": [
+                        "datasetIds": [
                                 "GEO:GSE19302"
                         ],
                         "dateAssigned": "2009-12-03T20:05:44-00:00"

--- a/ingest/htp/htpId.json
+++ b/ingest/htp/htpId.json
@@ -21,7 +21,7 @@
 	    "uniqueItems": true
         },
 	"crossReferences": {
-      "description": "an optional cross references to the MOD sample or dataset page.",
+      "description": "optional cross references to the MOD sample or dataset page.",
 	"type":"array",
 		"items":{      
 			"$ref" : "../crossReference.json#"

--- a/ingest/htp/htpId.json
+++ b/ingest/htp/htpId.json
@@ -15,7 +15,7 @@
         "alternateIds": {
             "description": "list of optional cross reference ids to the primary dataset id.",
             "type": "array",
-            "item": {
+            "items": {
                 "$ref": "../globalId.json#/properties/globalId"
             },
 	    "uniqueItems": true
@@ -23,7 +23,7 @@
 	"crossReferences": {
       "description": "an optional cross references to the MOD sample or dataset page.",
 	"type":"array",
-		"item":{      
+		"items":{      
 			"$ref" : "../crossReference.json#"
 		},
 		"uniqueItems": true

--- a/ingest/htp/htpId.json
+++ b/ingest/htp/htpId.json
@@ -12,7 +12,7 @@
             "$ref": "../globalId.json#/properties/globalId",
             "description": "The ID from the data provider for the dataset. When available, this is the GEO ID. When no GEO ID is available, it will be the ArrayExpress ID. When these both are unavailable, it will be the MOD ID."
         },
-        "secondaryId": {
+        "alternateIds": {
             "description": "list of optional cross reference ids to the primary dataset id.",
             "type": "array",
             "item": {
@@ -20,9 +20,13 @@
             },
 	    "uniqueItems": true
         },
-	"crossReference": {
-      "description": "an optional cross reference to the MOD sample or dataset page.",
-      "$ref" : "../crossReference.json#"
+	"crossReferences": {
+      "description": "an optional cross references to the MOD sample or dataset page.",
+	"type":"array",
+		"item":{      
+			"$ref" : "../crossReference.json#"
+		},
+		"uniqueItems": true
     }
     }
 }


### PR DESCRIPTION
Updated HTP metadata schema as discussed in DQM meeting, 7/7/2020. Pluralized array labels, made categoryTags, sampleType and assayType required; made crossReferences for datasets and datasamples an array; fixed some typos and paths