### PR TITLE
AGR-1144 resourceDescriptor updates.

### DIFF
--- a/ingest/species/species.yaml
+++ b/ingest/species/species.yaml
@@ -78,6 +78,8 @@
    dataProviderShortName: SGD
   phylogenicOrder: 70
 
+
+# NOTE: Hsa uses RGD for now,
 - taxonId: NCBITaxon:9606
   shortName: Hsa
   fullName: Homo sapiens

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -269,14 +269,14 @@
   - name: htp/dataset
     url: https://www.ebi.ac.uk/arrayexpress/experiments/[%s]
 
-    - db_prefix: BIOGRID
-    name: Biological General Repository for Interaction Datasets
-    example_id: BIOGRID:1276808
-    gid_pattern: "^BIOGRID:\\d+$"
-    default_url: https://thebiogrid.org/interaction/[%s]
-    pages:
-    - name: gene/interactions
-      url: https://thebiogrid.org/interaction/[%s]
+- db_prefix: BIOGRID
+  name: Biological General Repository for Interaction Datasets
+  example_id: BIOGRID:1276808
+  gid_pattern: "^BIOGRID:\\d+$"
+  default_url: https://thebiogrid.org/interaction/[%s]
+  pages:
+  - name: gene/interactions
+    url: https://thebiogrid.org/interaction/[%s]
     
 - db_prefix: CHEBI
   name: Chemical Entities of Biological Interest Ontology
@@ -327,6 +327,12 @@
   example_gid: ECO:0000000
   gid_pattern: "^ECO:\\d+$"
   default_url: http://www.evidenceontology.org/browse/#ECO:[%s]
+
+- db_prefix: EFO
+  name: Experimental Factor Ontology
+  example_gid: EFO:EFO_0000000
+  gid_pattern: "^EFO:\\d+$"
+  default_url: http://www.ebi.ac.uk/efo/EFO_[%s]
 
 - db_prefix: EMDB
   name: Electron Microscopy Data Bank
@@ -393,7 +399,19 @@
   pages:
   - name: gene/interactions
     url: https://www.ebi.ac.uk/intact/pages/details/details.xhtml?interactionAc=[%s]
-    
+
+- db_prefix: KEGG
+  name: Kyoto Encyclopedia of Genes and Genomes
+  example_id: ?
+  gid_pattern: None?
+  default_url: http://www.genome.jp/dbget-bin/www_bget?map[%s]
+
+- db_prefix: MESH
+  name: Medical Subject Headings)
+  example_gid: NCBITaxon:7227
+  gid_pattern: "^NCBITaxon:\\d+$"
+  default_url: https://www.ncbi.nlm.nih.gov/mesh/[%s]
+
 - db_prefix: MINT
   name: The Molecular INTeraction database
   example_id: MINT:MINT-1954459
@@ -420,10 +438,14 @@
   - name: biogrid/orcs
     url: https://orcs.thebiogrid.org/Gene/[%s]
 
+- db_prefix: NCI
+  name: NCI Thesaurus
+  example_gid:
+  default_url : https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=[%s]
 - db_prefix: OMIM
   name: OMIM
-  example_id: OMIM:600483
-  gid_pattern: "^OMIM:\\d+$"
+  example_id: OMIM:600483, OMIM:PS100200
+  gid_pattern: "^OMIM:[PS]*\\d+$"
   default_url: https://www.omim.org/entry/[%s]
   pages:
     - name: homepage
@@ -434,12 +456,21 @@
       url: https://www.omim.org/entry/[%s]
     - name: disease
       url: https://www.omim.org/entry/[%s]
-  
+    -name: ont
+      url: https://www.omim.org/phenotypicSeries/[%s]
+
+# maybe make this an alias of Orphanet instead.
+- db_prefix: ORDO
+  name: ORDO
+  example_id: ORDO:600483
+    gid_pattern: "^ORDO:\\d+$"
+    default_url:  https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=[%s]
+    
 - db_prefix: Orphanet
   name: Orphanet
   example_id: ORPHA:600483
   gid_pattern: "^ORPHA:\\d+$"
-  default_url:  https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=[%s]    
+  default_url:  https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=[%s]
 
 - db_prefix: PANTHER
   name: PANTHER

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -458,6 +458,9 @@
   example_gid: NCI:C7646
   gid_pattern: "^NCI:C\\d+$"
   default_url : https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=[%s]
+  pages:
+    - name: pub
+      url: https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=[%s]
 
 - db_prefix: OMIM
   name: OMIM

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -361,13 +361,13 @@
     url: https://www.ncbi.nlm.nih.gov/gds/?term=[%s]
 
 - db_prefix: GXA
-    name: ExpressionAtlas
-    example_id: GXA:E-MTAB-8344
-    gid_pattern: "^GXA:\\w+$"
-    default_url: https://www.ebi.ac.uk/gxa/experiments/[%s]/Results
-    pages:
-    - name: htp/dataset
-      url: https://www.ebi.ac.uk/gxa/experiments/[%s]/Results
+  name: ExpressionAtlas
+  example_id: GXA:E-MTAB-8344
+  gid_pattern: "^GXA:\\w+$"
+  default_url: https://www.ebi.ac.uk/gxa/experiments/[%s]/Results
+  pages:
+  - name: htp/dataset
+    url: https://www.ebi.ac.uk/gxa/experiments/[%s]/Results
 
 - db_prefix: HGNC
   name: HGNC

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -407,9 +407,9 @@
   default_url: http://www.genome.jp/dbget-bin/www_bget?map[%s]
 
 - db_prefix: MESH
-  name: Medical Subject Headings)
-  example_gid: NCBITaxon:7227
-  gid_pattern: "^NCBITaxon:\\d+$"
+  name: Medical Subject Headings
+  example_gid: NotSure
+  gid_pattern: "MESh??:\\d+$"
   default_url: https://www.ncbi.nlm.nih.gov/mesh/[%s]
 
 - db_prefix: MINT

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -266,8 +266,8 @@
   gid_pattern: "^ArrayExpress:\\w+$"
   default_url: https://www.ebi.ac.uk/arrayexpress/experiments/[%s]
   pages:
-  - name: htp/dataset
-    url: https://www.ebi.ac.uk/arrayexpress/experiments/[%s]
+    - name: htp/dataset
+      url: https://www.ebi.ac.uk/arrayexpress/experiments/[%s]
 
 - db_prefix: BIOGRID
   name: Biological General Repository for Interaction Datasets

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -362,7 +362,13 @@
   example_id: ENSEMBL:FBgn0000490
   gid_pattern: "^ENSEMBL:\\w+$"
   default_url: http://www.ensembl.org/id/[%s] 
-    
+
+- db_prefix: GARD
+  name: GARD
+  example_id: GARD:262
+  gid_pattern: "^GARD:\\d+$"
+  default_url: https://rarediseases.info.nih.gov/diseases/[%s]/index
+
 - db_prefix: GEO
   name: Gene Expression Omnibus
   example_id: GEO:GSE59105

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -55,16 +55,6 @@
       url: http://www.informatics.jax.org/accession/[%s]
 
 #
-# Wikipedia
-#
-
-- db_prefix: WIKIP
-  name: Wikipedia
-  example_id: WIKIP:BRCA2
-  gid_pattern: "^WIKIP:\\S+$"
-  default_url: https://en.wikipedia.org/wiki/[%s]
-
-#
 # RGD
 #
 
@@ -226,24 +216,6 @@
     - name: construct
       url: https://www.wormbase.org/db/get?name=[%s];class=Construct
 
-- db_prefix: WBls
-  name: WormBase life-stage Ontology
-  example_gid: WBls:0000001
-  gid_pattern: "^WBls:\\d+$"
-  default_url: https://www.wormbase.org/db/get?name=WBls:[%s];class=Life_stage
-
-- db_prefix: WBbt
-  name: WormBase anatomy Ontology
-  example_gid: WBbt:0008611
-  gid_pattern: "^WBbt:\\d+$"
-  default_url: https://www.wormbase.org/db/get?name=WBbt:[%s];class=Anatomy
-
-- db_prefix: WBPhenotype
-  name: WormBase Phenotype Ontology
-  example_gid: WBPhenotype:0000517
-  gid_pattern: "^WBPhenotype:\\d+$"
-  default_url: https://www.wormbase.org/db/get?name=WBPhenotype:[%s];class=Phenotype
-
 #
 # SGD
 #
@@ -285,91 +257,47 @@
 
 #
 # External resources
+# Ordered to make finding easier. Please add new ones in proper place.
 #
 
-- db_prefix: ECO
-  name: Evidence and Conclusion Ontology
-  example_gid: ECO:0000000
-  gid_pattern: "^ECO:\\d+$"
-  default_url: http://www.evidenceontology.org/browse/#ECO:[%s]
-
-- db_prefix: HGNC
-  name: HGNC
-  example_gid: HGNC:33510
-  gid_pattern: "^HGNC:\\d+$"
-  default_url: http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:[%s]
+- db_prefix: ArrayExpress
+  name: ArrayExpress
+  example_id: ArrayExpress:E-MEXP-31
+  gid_pattern: "^ArrayExpress:\\w+$"
+  default_url: https://www.ebi.ac.uk/arrayexpress/experiments/[%s]
   pages:
-  - name: gene
-    url: http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:[%s]
-  - name: gene/MODinteractions
-    url: https://rgd.mcw.edu/rgdweb/cytoscape/cy.html?species=1&identifiers=HGNC:[%s]
-  - name: disease/human
-    url: https://rgd.mcw.edu/rgdweb/ontology/annot.html?species=Human&x=1&acc_id=[%s]#annot
+  - name: htp/dataset
+    url: https://www.ebi.ac.uk/arrayexpress/experiments/[%s]
 
-- db_prefix: NCBI_Gene
-  name: NCBI Gene
-  example_gid: NCBI_Gene:33432
-  gid_pattern: "^NCBI_Gene:\\d+$"
-  default_url: https://www.ncbi.nlm.nih.gov/gene/[%s]
+    - db_prefix: BIOGRID
+    name: Biological General Repository for Interaction Datasets
+    example_id: BIOGRID:1276808
+    gid_pattern: "^BIOGRID:\\d+$"
+    default_url: https://thebiogrid.org/interaction/[%s]
+    pages:
+    - name: gene/interactions
+      url: https://thebiogrid.org/interaction/[%s]
+    
+- db_prefix: CHEBI
+  name: Chemical Entities of Biological Interest Ontology
+  example_gid: CHEBI:53438
+  gid_pattern: "^CHEBI:\\d+$"
+  default_url: http://www.ebi.ac.uk/chebi/searchId.do?chebiId=[%s]
+
+- db_prefix: DIP
+  name: Database of Interacting Proteins
+  example_id: DIP:DIP-88423E
+  gid_pattern: "^DIP:DIP(\\:)?\\-\\d{1,}[ENXS]$"
+  default_url: http://dip.mbi.ucla.edu/dip/record?ac=[%s]
   pages:
-  - name: gene/interactions
-    url: https://www.ncbi.nlm.nih.gov/gene/[%s]
-  - name: biogrid/orcs
-    url: https://orcs.thebiogrid.org/Gene/[%s]
-
-- db_prefix: RefSeq
-  name: RefSeq
-  example_gid: RefSeq:NT_033778
-  gid_pattern: "^RefSeq:\\w+$"
-  default_url: https://www.ncbi.nlm.nih.gov/nuccore/[%s]
-
-- db_prefix: UniProtKB
-  name: UniProtKB
-  example_gid: UniProtKB:P07713
-  gid_pattern: "^UniProtKB:\\w+$"
-  default_url: http://www.uniprot.org/uniprot/[%s]
-
-- db_prefix: ENSEMBL
-  name: Ensembl
-  example_id: ENSEMBL:FBgn0000490
-  gid_pattern: "^ENSEMBL:\\w+$"
-  default_url: http://www.ensembl.org/id/[%s] 
-
-- db_prefix: RNAcentral
-  name: RNAcentral
-  example_gid: RNAcentral:URS000075C808
-  gid_pattern: "^RNAcentral:\\w+$"
-  default_url: http://rnacentral.org/rna/[%s]
-
-- db_prefix: PMID
-  name: PubMed
-  example_gid: PMID:26447131
-  gid_pattern: "^PMID:\\d+$"
-  default_url: https://www.ncbi.nlm.nih.gov/pubmed/[%s]
+    - name: gene/interactions
+      url: http://dip.mbi.ucla.edu/dip/record?ac=[%s]
 
 - db_prefix: DOI
   name: DOI
   example_gid: DOI:10.3389/fcimb.2016.00052
   gid_pattern: "^DOI:\\S+$"
   default_url: doi.org/[%s]
-
-- db_prefix: DRSC
-  name: DRSC
-  example_gid: DRSC:FBgn0000490
-  gid_pattern: "^DRSC:\\S+$"
-  default_url: 
-    
-- db_prefix: NCBITaxon
-  name: NCBI Taxonomy
-  example_gid: NCBITaxon:7227
-  gid_pattern: "^NCBITaxon:\\d+$"
-  default_url: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=[%s]
-
-- db_prefix: SO
-  name: Sequence Ontology
-  example_gid: SO:0001217
-  gid_pattern: "^SO:\\d+$"
-  default_url: http://www.sequenceontology.org/browser/current_svn/term/SO:[%s]
 
 - db_prefix: DOID
   name: Disease Ontology
@@ -388,59 +316,17 @@
     - name: disease/wb
       url: https://www.wormbase.org/resources/disease/[%s]
 
-- db_prefix: ZECO
-  name: Zebrafish Environment Condition Ontology
-  example_gid: ZECO:0000103
-  gid_pattern: "^ZECO:\\d+$"
-  default_url: https://zfin.org/action/ontology/term-detail/ZECO:[%s]
+- db_prefix: DRSC
+  name: DRSC
+  example_gid: DRSC:FBgn0000490
+  gid_pattern: "^DRSC:\\S+$"
+  default_url: 
 
-- db_prefix: CHEBI
-  name: Chemical Entities of Biological Interest Ontology
-  example_gid: CHEBI:53438
-  gid_pattern: "^CHEBI:\\d+$"
-  default_url: http://www.ebi.ac.uk/chebi/searchId.do?chebiId=[%s]
-
-- db_prefix: ZFA
-  name: Zebrafish Anatomy Ontology
-  example_id: ZFA:0001327
-  gid_pattern: "^ZFA:\\d+$"
-  default_url: http://zfin.org/action/ontology/term-detail/ZFA:[%s]
-
-- db_prefix: PANTHER
-  name: PANTHER
-  example_id: PANTHER:PTHR11662
-  gid_pattern: "^PANTHER:PTHR\\d+$"
-  default_url: http://pantherdb.org/panther/family.do?clsAccession=[%s]
-
-- db_prefix: OMIM
-  name: OMIM
-  example_id: OMIM:600483
-  gid_pattern: "^OMIM:\\d+$"
-  default_url: https://www.omim.org/entry/[%s]
-  pages:
-    - name: homepage
-      url: https://www.omim.org/
-    - name: gene
-      url: https://www.omim.org/entry/[%s]
-    - name: gene/interactions
-      url: https://www.omim.org/entry/[%s]
-    - name: disease
-      url: https://www.omim.org/entry/[%s]
-
-- db_prefix: Orphanet
-  name: Orphanet
-  example_id: ORPHA:600483
-  gid_pattern: "^ORPHA:\\d+$"
-  default_url:  https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=[%s]
-
-- db_prefix: DIP
-  name: Database of Interacting Proteins
-  example_id: DIP:DIP-88423E
-  gid_pattern: "^DIP:DIP(\\:)?\\-\\d{1,}[ENXS]$"
-  default_url: http://dip.mbi.ucla.edu/dip/record?ac=[%s]
-  pages:
-    - name: gene/interactions
-      url: http://dip.mbi.ucla.edu/dip/record?ac=[%s]
+- db_prefix: ECO
+  name: Evidence and Conclusion Ontology
+  example_gid: ECO:0000000
+  gid_pattern: "^ECO:\\d+$"
+  default_url: http://www.evidenceontology.org/browse/#ECO:[%s]
 
 - db_prefix: EMDB
   name: Electron Microscopy Data Bank
@@ -451,6 +337,45 @@
   - name: gene/interactions
     url: http://www.ebi.ac.uk/pdbe/entry/emdb/[%s]
 
+- db_prefix: ENSEMBL
+  name: Ensembl
+  example_id: ENSEMBL:FBgn0000490
+  gid_pattern: "^ENSEMBL:\\w+$"
+  default_url: http://www.ensembl.org/id/[%s] 
+    
+- db_prefix: GEO
+  name: Gene Expression Omnibus
+  example_id: GEO:GSE59105
+  gid_pattern: "^GEO:GS[EM]\\d+$"
+  default_url: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=[%s]
+  pages:
+  - name: htp/dataset
+    url: https://www.ncbi.nlm.nih.gov/gds/?term=[%s]
+  - name: htp/datasetsample
+    url: https://www.ncbi.nlm.nih.gov/gds/?term=[%s]
+
+- db_prefix: GXA
+    name: ExpressionAtlas
+    example_id: GXA:E-MTAB-8344
+    gid_pattern: "^GXA:\\w+$"
+    default_url: https://www.ebi.ac.uk/gxa/experiments/[%s]/Results
+    pages:
+    - name: htp/dataset
+      url: https://www.ebi.ac.uk/gxa/experiments/[%s]/Results
+
+- db_prefix: HGNC
+  name: HGNC
+  example_gid: HGNC:33510
+  gid_pattern: "^HGNC:\\d+$"
+  default_url: http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:[%s]
+  pages:
+  - name: gene
+    url: http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:[%s]
+  - name: gene/MODinteractions
+    url: https://rgd.mcw.edu/rgdweb/cytoscape/cy.html?species=1&identifiers=HGNC:[%s]
+  - name: disease/human
+    url: https://rgd.mcw.edu/rgdweb/ontology/annot.html?species=Human&x=1&acc_id=[%s]#annot
+
 - db_prefix: IMEX
   name: The International Molecular Exchange Consortium
   example_id: IMEX:IM-10766-6
@@ -459,7 +384,7 @@
   pages:
   - name: gene/interactions
     url: https://www.ebi.ac.uk/intact/pages/details/details.xhtml?interactionAc=[%s]
-
+  
 - db_prefix: INTACT
   name: IntAct Molecular Interaction Database
   example_id: INTACT:EBI-1000008
@@ -477,7 +402,51 @@
   pages:
   - name: gene/interactions
     url: https://mint.bio.uniroma2.it/index.php/results-interactions/?id=[%s]
-    
+
+- db_prefix: NCBITaxon
+    name: NCBI Taxonomy
+    example_gid: NCBITaxon:7227
+    gid_pattern: "^NCBITaxon:\\d+$"
+    default_url: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=[%s]
+
+- db_prefix: NCBI_Gene
+  name: NCBI Gene
+  example_gid: NCBI_Gene:33432
+  gid_pattern: "^NCBI_Gene:\\d+$"
+  default_url: https://www.ncbi.nlm.nih.gov/gene/[%s]
+  pages:
+  - name: gene/interactions
+    url: https://www.ncbi.nlm.nih.gov/gene/[%s]
+  - name: biogrid/orcs
+    url: https://orcs.thebiogrid.org/Gene/[%s]
+
+- db_prefix: OMIM
+  name: OMIM
+  example_id: OMIM:600483
+  gid_pattern: "^OMIM:\\d+$"
+  default_url: https://www.omim.org/entry/[%s]
+  pages:
+    - name: homepage
+      url: https://www.omim.org/
+    - name: gene
+      url: https://www.omim.org/entry/[%s]
+    - name: gene/interactions
+      url: https://www.omim.org/entry/[%s]
+    - name: disease
+      url: https://www.omim.org/entry/[%s]
+  
+- db_prefix: Orphanet
+  name: Orphanet
+  example_id: ORPHA:600483
+  gid_pattern: "^ORPHA:\\d+$"
+  default_url:  https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=[%s]    
+
+- db_prefix: PANTHER
+  name: PANTHER
+  example_id: PANTHER:PTHR11662
+  gid_pattern: "^PANTHER:PTHR\\d+$"
+  default_url: http://pantherdb.org/panther/family.do?clsAccession=[%s]
+
 - db_prefix: PDBE
   name: Protein Data Bank in Europe
   example_id: PDBE:1FHI
@@ -487,6 +456,12 @@
   - name: gene/interactions
     url: https://www.ebi.ac.uk/pdbe/entry/pdb/[%s]
 
+- db_prefix: PMID
+  name: PubMed
+  example_gid: PMID:26447131
+  gid_pattern: "^PMID:\\d+$"
+  default_url: https://www.ncbi.nlm.nih.gov/pubmed/[%s]
+  
 - db_prefix: RCSB_PDB
   name: RCSB Protein Data Bank
   example_id: RCSB_PDB:1AGR
@@ -495,6 +470,54 @@
   pages:
   - name: gene/interactions
     url: https://www.rcsb.org/structure/[%s]
+
+- db_prefix: RNAcentral
+  name: RNAcentral
+  example_gid: RNAcentral:URS000075C808
+  gid_pattern: "^RNAcentral:\\w+$"
+  default_url: http://rnacentral.org/rna/[%s]
+
+- db_prefix: RefSeq
+  name: RefSeq
+  example_gid: RefSeq:NT_033778
+  gid_pattern: "^RefSeq:\\w+$"
+  default_url: https://www.ncbi.nlm.nih.gov/nuccore/[%s]
+
+- db_prefix: SO
+  name: Sequence Ontology
+  example_gid: SO:0001217
+  gid_pattern: "^SO:\\d+$"
+  default_url: http://www.sequenceontology.org/browser/current_svn/term/SO:[%s]
+
+- db_prefix: UniProtKB
+  name: UniProtKB
+  example_gid: UniProtKB:P07713
+  gid_pattern: "^UniProtKB:\\w+$"
+  default_url: http://www.uniprot.org/uniprot/[%s]
+
+- db_prefix: WBbt
+  name: WormBase anatomy Ontology
+  example_gid: WBbt:0008611
+  gid_pattern: "^WBbt:\\d+$"
+  default_url: https://www.wormbase.org/db/get?name=WBbt:[%s];class=Anatomy
+
+- db_prefix: WBls
+  name: WormBase life-stage Ontology
+  example_gid: WBls:0000001
+  gid_pattern: "^WBls:\\d+$"
+  default_url: https://www.wormbase.org/db/get?name=WBls:[%s];class=Life_stage
+
+- db_prefix: WBPhenotype
+  name: WormBase Phenotype Ontology
+  example_gid: WBPhenotype:0000517
+  gid_pattern: "^WBPhenotype:\\d+$"
+  default_url: https://www.wormbase.org/db/get?name=WBPhenotype:[%s];class=Phenotype
+
+- db_prefix: WIKIP
+  name: Wikipedia
+  example_id: WIKIP:BRCA2
+  gid_pattern: "^WIKIP:\\S+$"
+  default_url: https://en.wikipedia.org/wiki/[%s]
 
 - db_prefix: WWPDB
   name: Worldwide Protein Data Bank
@@ -505,40 +528,16 @@
   - name: gene/interactions
     url: https://www.rcsb.org/structure/[%s]
 
-- db_prefix: BIOGRID
-  name: Biological General Repository for Interaction Datasets
-  example_id: BIOGRID:1276808
-  gid_pattern: "^BIOGRID:\\d+$"
-  default_url: https://thebiogrid.org/interaction/[%s]
-  pages:
-  - name: gene/interactions
-    url: https://thebiogrid.org/interaction/[%s]
-    
-- db_prefix: GEO
-  name: Gene Expression Omnibus
-  example_id: GEO:GSE59105
-  gid_pattern: "^GEO:GS[EM]\\d+$"
-  default_url: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=[%s]
-  pages:
-  - name: htp/dataset
-    url: https://www.ncbi.nlm.nih.gov/gds/?term=[%s]
-  - name: htp/datasetsample
-    url: https://www.ncbi.nlm.nih.gov/gds/?term=[%s]
+- db_prefix: ZECO
+  name: Zebrafish Environment Condition Ontology
+  example_gid: ZECO:0000103
+  gid_pattern: "^ZECO:\\d+$"
+  default_url: https://zfin.org/action/ontology/term-detail/ZECO:[%s]
 
-- db_prefix: ArrayExpress
-  name: ArrayExpress
-  example_id: ArrayExpress:E-MEXP-31
-  gid_pattern: "^ArrayExpress:\\w+$"
-  default_url: https://www.ebi.ac.uk/arrayexpress/experiments/[%s]
-  pages:
-  - name: htp/dataset
-    url: https://www.ebi.ac.uk/arrayexpress/experiments/[%s]
+- db_prefix: ZFA
+  name: Zebrafish Anatomy Ontology
+  example_id: ZFA:0001327
+  gid_pattern: "^ZFA:\\d+$"
+  default_url: http://zfin.org/action/ontology/term-detail/ZFA:[%s]
 
-- db_prefix: GXA
-  name: ExpressionAtlas
-  example_id: GXA:E-MTAB-8344
-  gid_pattern: "^GXA:\\w+$"
-  default_url: https://www.ebi.ac.uk/gxa/experiments/[%s]/Results
-  pages:
-  - name: htp/dataset
-    url: https://www.ebi.ac.uk/gxa/experiments/[%s]/Results
+

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -340,8 +340,8 @@
   gid_pattern: "^(EMDB:EMDB?-\\d{4})|(EMDB:\\d{4})$"
   default_url: http://www.ebi.ac.uk/pdbe/entry/emdb/[%s]
   pages:
-  - name: gene/interactions
-    url: http://www.ebi.ac.uk/pdbe/entry/emdb/[%s]
+    - name: gene/interactions
+      url: http://www.ebi.ac.uk/pdbe/entry/emdb/[%s]
 
 - db_prefix: ENSEMBL
   name: Ensembl
@@ -355,10 +355,10 @@
   gid_pattern: "^GEO:GS[EM]\\d+$"
   default_url: https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=[%s]
   pages:
-  - name: htp/dataset
-    url: https://www.ncbi.nlm.nih.gov/gds/?term=[%s]
-  - name: htp/datasetsample
-    url: https://www.ncbi.nlm.nih.gov/gds/?term=[%s]
+    - name: htp/dataset
+      url: https://www.ncbi.nlm.nih.gov/gds/?term=[%s]
+    - name: htp/datasetsample
+      url: https://www.ncbi.nlm.nih.gov/gds/?term=[%s]
 
 - db_prefix: GXA
   name: ExpressionAtlas
@@ -442,6 +442,7 @@
   name: NCI Thesaurus
   example_gid:
   default_url : https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=[%s]
+
 - db_prefix: OMIM
   name: OMIM
   example_id: OMIM:600483, OMIM:PS100200
@@ -463,8 +464,8 @@
 - db_prefix: ORDO
   name: ORDO
   example_id: ORDO:600483
-    gid_pattern: "^ORDO:\\d+$"
-    default_url:  https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=[%s]
+  gid_pattern: "^ORDO:\\d+$"
+  default_url:  https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=[%s]
     
 - db_prefix: Orphanet
   name: Orphanet

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -275,8 +275,8 @@
   gid_pattern: "^BIOGRID:\\d+$"
   default_url: https://thebiogrid.org/interaction/[%s]
   pages:
-  - name: gene/interactions
-    url: https://thebiogrid.org/interaction/[%s]
+    - name: gene/interactions
+      url: https://thebiogrid.org/interaction/[%s]
     
 - db_prefix: CHEBI
   name: Chemical Entities of Biological Interest Ontology

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -1,6 +1,7 @@
 # AGR Schema Resource Descriptors YAML.
 # When submitting identifiers, please use the appropriate example_id/gid field listed below.
 
+
 #
 # MGI
 #
@@ -69,6 +70,10 @@
 
 - db_prefix: RGD
   name: RGD
+  aliases: 
+    - taxon: "10116"
+    - taxon_str: NCBITaxon:10116
+    - abbreviation: Rno
   example_gid: RGD:1311419
   gid_pattern: "^RGD:\\d+$"
   default_url: https://rgd.mcw.edu/rgdweb/elasticResults.html?term=RGD:[%s]

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -422,8 +422,8 @@
 
 - db_prefix: MESH
   name: Medical Subject Headings
-  example_gid: NotSure
-  gid_pattern: "MESh??:\\d+$"
+  example_gid: MESH:D020516
+  gid_pattern: "MESH:D\\d+$"
   default_url: https://www.ncbi.nlm.nih.gov/mesh/[%s]
 
 - db_prefix: MINT

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -423,7 +423,7 @@
 - db_prefix: MESH
   name: Medical Subject Headings
   example_gid: MESH:D020516
-  gid_pattern: "MESH:D\\d+$"
+  gid_pattern: "^MESH:D\\d+$"
   default_url: https://www.ncbi.nlm.nih.gov/mesh/[%s]
 
 - db_prefix: MINT
@@ -454,7 +454,9 @@
 
 - db_prefix: NCI
   name: NCI Thesaurus
-  example_gid: SOmething
+  aliases: ['NCI_Thesaurus', 'NCI']
+  example_gid: NCI:C7646
+  gid_pattern: "^NCI:C\d+$"
   default_url : https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=[%s]
 
 - db_prefix: OMIM

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -559,8 +559,8 @@
   gid_pattern: "^RCSB_PDB:\\w+$"
   default_url: https://www.rcsb.org/structure/[%s]
   pages:
-    - name: gene/interactions
-      url: https://www.rcsb.org/structure/[%s]
+  - name: gene/interactions
+    url: https://www.rcsb.org/structure/[%s]
 
 - db_prefix: RNAcentral
   name: RNAcentral

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -22,6 +22,8 @@
       url: http://www.informatics.jax.org/reference/marker/MGI:[%s]
     - name: gene/phenotypes
       url: http://www.informatics.jax.org/marker/phenotypes/MGI:[%s]
+    - name: gene/phenotypes_impc
+      url: https://www.mousephenotype.org/data/genes/MGI:[%s]
     - name: allele
       url: http://www.informatics.jax.org/allele/MGI:[%s]
     - name: allele/references
@@ -74,6 +76,8 @@
       url: https://rgd.mcw.edu/rgdweb/report/gene/main.html?view=5&id=[%s]
     - name: gene/references
       url: https://rgd.mcw.edu/rgdweb/report/gene/main.html?view=5&id=[%s]
+    - name: gene/phenotypes
+      url: https://rgd.mcw.edu/rgdweb/report/gene/main.html?id=RGD:[%s]
     - name: disease/rat
       url: https://rgd.mcw.edu/rgdweb/ontology/annot.html?species=Rat&x=1&acc_id=[%s]#annot
     - name: disease/human
@@ -108,6 +112,8 @@
       url: https://zfin.org/[%s]/wt-expression
     - name: gene/references
       url: https://zfin.org/action/marker/citation-list/[%s]
+    - name: gene/phenotypes
+      url: https://zfin.org/action/marker/[%s]/phenotype-summary
     - name: allele
       url: https://zfin.org/[%s]
     - name: genotype
@@ -147,6 +153,8 @@
       url: https://flybase.org/reports/[%s].html#expression
     - name: gene/references
       url: https://flybase.org/reports/[%s].html#pubs
+    - name: gene/phenotypes
+      url: https://flybase.org/reports/[%s].html#phenotypes
     - name: allele
       url: https://flybase.org/reports/[%s].html
     - name: allele/references
@@ -174,6 +182,7 @@
 
 - db_prefix: WB
   name: WormBase genes
+  aliases: ['WORMBASE']
   example_gid: WB:WBGene00000064
   gid_pattern: "^WB:\\w+$"
   default_url: https://www.wormbase.org/get?name=[%s]
@@ -188,6 +197,8 @@
       url: http://www.wormbase.org/db/get?name=[%s];class=interaction
     - name: gene/references
       url: https://www.wormbase.org/db/get?name=[%s];class=Gene;widget=references
+    - name: gene/phenotypes
+      url: http://www.wormbase.org/db/get?name=[%s];class=Gene;widget=phenotype
     - name: gene/spell
       url: http://spell.wormbase.org/search/show_results?search_string=[%s]
     - name: gene/expression/annotation/detail
@@ -238,6 +249,8 @@
     url: https://www.yeastgenome.org/locus/[%s]/literature
   - name: gene/disease
     url: https://www.yeastgenome.org/locus/[%s]/disease
+  - name: gene/phenotypes
+    url: https://www.yeastgenome.org/locus/[%s]/phenotype
   - name: gene/MODinteractions
     url: https://www.yeastgenome.org/locus/[%s]/interaction#network
   - name: htp/dataset
@@ -477,6 +490,22 @@
   example_id: PANTHER:PTHR11662
   gid_pattern: "^PANTHER:PTHR\\d+$"
   default_url: http://pantherdb.org/panther/family.do?clsAccession=[%s]
+  pages:
+    - name: MGI
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=MGI=MGI=[%s]
+    - name: FB
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=FlyBase=[%s]
+    - name: RGD
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=RGD=[%s]
+    - name: ZFIN
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=ZFIN=[%s]
+    - name: WB
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=WB=[%s]
+    - name: HGNC
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=HGNC=[%s]
+    - name: SGD
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=SGD=[%s]
+
 
 - db_prefix: PDBE
   name: Protein Data Bank in Europe
@@ -489,13 +518,14 @@
 
 - db_prefix: PMID
   name: PubMed
-  aliases: ['pubmed', 'BOB']
+  aliases: ['pubmed']
   example_gid: PMID:26447131
   gid_pattern: "^PMID:\\d+$"
   default_url: https://www.ncbi.nlm.nih.gov/pubmed/[%s]
   
 - db_prefix: RCSB_PDB
   name: RCSB Protein Data Bank
+  aliases: ['RCSB PDB']
   example_id: RCSB_PDB:1AGR
   gid_pattern: "^RCSB_PDB:\\w+$"
   default_url: https://www.rcsb.org/structure/[%s]

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -483,6 +483,7 @@
     
 - db_prefix: Orphanet
   name: Orphanet
+  aliases: ['ORPHA']
   example_id: ORPHA:600483
   gid_pattern: "^ORPHA:\\d+$"
   default_url:  https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=[%s]

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -492,19 +492,19 @@
   default_url: http://pantherdb.org/panther/family.do?clsAccession=[%s]
   pages:
     - name: MGI
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=MGI=MGI=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=MGI=MGI=[%s]
     - name: FB
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=FlyBase=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=FlyBase=[%s]
     - name: RGD
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=RGD=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=RGD=[%s]
     - name: ZFIN
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=ZFIN=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=ZFIN=[%s]
     - name: WB
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=WormBase=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=WormBase=[%s]
     - name: HGNC
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=HGNC=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=HGNC=[%s]
     - name: SGD
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=SGD=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=SGD=[%s]
 
 
 - db_prefix: PDBE

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -480,7 +480,7 @@
 - db_prefix: ORDO
   name: ORDO
   example_id: ORDO:600483
-  gid_pattern: "^ORDO:\\d+[GARD]*:*\\d*$"
+  gid_pattern: "^ORDO:\\d+:*[GARD]*:*\\d*$"
   default_url:  https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=[%s]
     
 - db_prefix: Orphanet

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -422,10 +422,10 @@
       url: https://mint.bio.uniroma2.it/index.php/results-interactions/?id=[%s]
 
 - db_prefix: NCBITaxon
-    name: NCBI Taxonomy
-    example_gid: NCBITaxon:7227
-    gid_pattern: "^NCBITaxon:\\d+$"
-    default_url: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=[%s]
+  name: NCBI Taxonomy
+  example_gid: NCBITaxon:7227
+  gid_pattern: "^NCBITaxon:\\d+$"
+  default_url: https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=[%s]
 
 - db_prefix: NCBI_Gene
   name: NCBI Gene

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -145,7 +145,7 @@
   name: FlyBase
   example_gid: FB:FBgn0000490
   gid_pattern: "^FB:FB.+$"
-  default_url: https://flybase.org/reports/[%s]
+  default_url: https://flybase.org/reports/[%s].html
   pages:
     - name: gene
       url: https://flybase.org/reports/[%s].html

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -440,7 +440,7 @@
 
 - db_prefix: NCI
   name: NCI Thesaurus
-  example_gid:
+  example_gid: SOmething
   default_url : https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=[%s]
 
 - db_prefix: OMIM

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -480,7 +480,7 @@
 - db_prefix: ORDO
   name: ORDO
   example_id: ORDO:600483
-  gid_pattern: "^ORDO:\\d+$"
+  gid_pattern: "^ORDO:\\d+[GARD]*:*\\d*$"
   default_url:  https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=[%s]
     
 - db_prefix: Orphanet

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -396,6 +396,15 @@
     - name: disease/human
       url: https://rgd.mcw.edu/rgdweb/ontology/annot.html?species=Human&x=1&acc_id=[%s]#annot
 
+- db_prefix: ICD9CM
+  name: ICD9CM
+  ignore_url_generation: True
+  aliases: ['ICD10CM']
+
+- db_prefix: ICDO
+  name: ICDO
+  ignore_url_generation: True
+
 - db_prefix: IMEX
   name: The International Molecular Exchange Consortium
   example_id: IMEX:IM-10766-6
@@ -419,6 +428,10 @@
   example_id: KEGG:05220
   gid_pattern: "^KEGG:\\w*:*\\d+$"
   default_url: http://www.genome.jp/dbget-bin/www_bget?map[%s]
+
+- db_prefix: MEDDRA
+  name: MEDDRA
+  ignore_url_generation: True
 
 - db_prefix: MESH
   name: Medical Subject Headings
@@ -564,6 +577,16 @@
   example_gid: SO:0001217
   gid_pattern: "^SO:\\d+$"
   default_url: http://www.sequenceontology.org/browser/current_svn/term/SO:[%s]
+
+- db_prefix: SNOMED
+  name: SNOMED
+  ignore_url_generation: True
+  aliases: ['SNOMEDCT_US_2019_09_01', 'SNOMEDCT_US_2020_03_01', 'SNOMED_CT_US_2018_03_01',
+            'SNOMEDCT_US_2020_09_01', 'SNOMEDCT_2020_03_01', 'SNOMEDCT_US_2018_03_01']
+
+- db_prefix: UMLS_CUI
+  name: UMLS_CUI
+  ignore_url_generation: True
 
 - db_prefix: UniProtKB
   name: UniProtKB

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -492,19 +492,19 @@
   default_url: http://pantherdb.org/panther/family.do?clsAccession=[%s]
   pages:
     - name: MGI
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=MGI=MGI=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=PAN_BOOK&species=agr&seq=MGI=MGI=[%s]
     - name: FB
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=FlyBase=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=PAN_BOOK&species=agr&seq=FlyBase=[%s]
     - name: RGD
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=RGD=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=PAN_BOOK&species=agr&seq=RGD=[%s]
     - name: ZFIN
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=ZFIN=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=PAN_BOOK&species=agr&seq=ZFIN=[%s]
     - name: WB
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=WormBase=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=PAN_BOOK&species=agr&seq=WormBase=[%s]
     - name: HGNC
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=HGNC=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=PAN_BOOK&species=agr&seq=HGNC=[%s]
     - name: SGD
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%b]&species=agr&seq=SGD=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=PAN_BOOK&species=agr&seq=SGD=[%s]
 
 
 - db_prefix: PDBE

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -311,7 +311,7 @@
   name: DOI
   example_gid: DOI:10.3389/fcimb.2016.00052
   gid_pattern: "^DOI:\\S+$"
-  default_url: https://doi.org/[%s]
+  default_url: https://doi.org/doi:[%s]
 
 - db_prefix: DOID
   name: Disease Ontology

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -366,8 +366,8 @@
   gid_pattern: "^GXA:\\w+$"
   default_url: https://www.ebi.ac.uk/gxa/experiments/[%s]/Results
   pages:
-  - name: htp/dataset
-    url: https://www.ebi.ac.uk/gxa/experiments/[%s]/Results
+    - name: htp/dataset
+      url: https://www.ebi.ac.uk/gxa/experiments/[%s]/Results
 
 - db_prefix: HGNC
   name: HGNC
@@ -375,12 +375,12 @@
   gid_pattern: "^HGNC:\\d+$"
   default_url: http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:[%s]
   pages:
-  - name: gene
-    url: http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:[%s]
-  - name: gene/MODinteractions
-    url: https://rgd.mcw.edu/rgdweb/cytoscape/cy.html?species=1&identifiers=HGNC:[%s]
-  - name: disease/human
-    url: https://rgd.mcw.edu/rgdweb/ontology/annot.html?species=Human&x=1&acc_id=[%s]#annot
+    - name: gene
+      url: http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:[%s]
+    - name: gene/MODinteractions
+      url: https://rgd.mcw.edu/rgdweb/cytoscape/cy.html?species=1&identifiers=HGNC:[%s]
+    - name: disease/human
+      url: https://rgd.mcw.edu/rgdweb/ontology/annot.html?species=Human&x=1&acc_id=[%s]#annot
 
 - db_prefix: IMEX
   name: The International Molecular Exchange Consortium
@@ -388,8 +388,8 @@
   gid_pattern: "^IMEX:IM-\\d+(-?)(\\d+?)$"
   default_url: https://www.ebi.ac.uk/intact/pages/details/details.xhtml?interactionAc=[%s]
   pages:
-  - name: gene/interactions
-    url: https://www.ebi.ac.uk/intact/pages/details/details.xhtml?interactionAc=[%s]
+    - name: gene/interactions
+      url: https://www.ebi.ac.uk/intact/pages/details/details.xhtml?interactionAc=[%s]
   
 - db_prefix: INTACT
   name: IntAct Molecular Interaction Database
@@ -397,8 +397,8 @@
   gid_pattern: "^INTACT:EBI\\-[0-9]+$"
   default_url: https://www.ebi.ac.uk/intact/pages/details/details.xhtml?interactionAc=[%s]
   pages:
-  - name: gene/interactions
-    url: https://www.ebi.ac.uk/intact/pages/details/details.xhtml?interactionAc=[%s]
+    - name: gene/interactions
+      url: https://www.ebi.ac.uk/intact/pages/details/details.xhtml?interactionAc=[%s]
 
 - db_prefix: KEGG
   name: Kyoto Encyclopedia of Genes and Genomes
@@ -418,8 +418,8 @@
   gid_pattern: "^MINT:MINT\\-\\d{1,7}$"
   default_url: https://mint.bio.uniroma2.it/index.php/results-interactions/?id=[%s]
   pages:
-  - name: gene/interactions
-    url: https://mint.bio.uniroma2.it/index.php/results-interactions/?id=[%s]
+    - name: gene/interactions
+      url: https://mint.bio.uniroma2.it/index.php/results-interactions/?id=[%s]
 
 - db_prefix: NCBITaxon
     name: NCBI Taxonomy
@@ -433,10 +433,10 @@
   gid_pattern: "^NCBI_Gene:\\d+$"
   default_url: https://www.ncbi.nlm.nih.gov/gene/[%s]
   pages:
-  - name: gene/interactions
-    url: https://www.ncbi.nlm.nih.gov/gene/[%s]
-  - name: biogrid/orcs
-    url: https://orcs.thebiogrid.org/Gene/[%s]
+    - name: gene/interactions
+      url: https://www.ncbi.nlm.nih.gov/gene/[%s]
+    - name: biogrid/orcs
+      url: https://orcs.thebiogrid.org/Gene/[%s]
 
 - db_prefix: NCI
   name: NCI Thesaurus
@@ -484,8 +484,8 @@
   gid_pattern: "^PDBE:\\w+$"
   default_url: https://www.ebi.ac.uk/pdbe/entry/pdb/[%s]
   pages:
-  - name: gene/interactions
-    url: https://www.ebi.ac.uk/pdbe/entry/pdb/[%s]
+    - name: gene/interactions
+      url: https://www.ebi.ac.uk/pdbe/entry/pdb/[%s]
 
 - db_prefix: PMID
   name: PubMed
@@ -499,8 +499,8 @@
   gid_pattern: "^RCSB_PDB:\\w+$"
   default_url: https://www.rcsb.org/structure/[%s]
   pages:
-  - name: gene/interactions
-    url: https://www.rcsb.org/structure/[%s]
+    - name: gene/interactions
+      url: https://www.rcsb.org/structure/[%s]
 
 - db_prefix: RNAcentral
   name: RNAcentral
@@ -556,8 +556,8 @@
   gid_pattern: "^WWPDB:\\w+$"
   default_url: https://www.rcsb.org/structure/[%s]
   pages:
-  - name: gene/interactions
-    url: https://www.rcsb.org/structure/[%s]
+    - name: gene/interactions
+      url: https://www.rcsb.org/structure/[%s]
 
 - db_prefix: ZECO
   name: Zebrafish Environment Condition Ontology

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -457,7 +457,7 @@
       url: https://www.omim.org/entry/[%s]
     - name: disease
       url: https://www.omim.org/entry/[%s]
-    -name: ont
+    - name: ont
       url: https://www.omim.org/phenotypicSeries/[%s]
 
 # maybe make this an alias of Orphanet instead.

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -231,7 +231,7 @@
   - name: gene/interactions
     url: http://www.yeastgenome.org/locus/[%s]/interaction
   - name: homepage
-    url: http://www.yeastgenome.org/
+    url: http://www.yeastgenome.org/[%s]
   - name: gene/spell
     url: https://spell.yeastgenome.org/search/show_results?search_string=[%s]
   - name: gene/references

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -574,12 +574,6 @@
   gid_pattern: "^RefSeq:\\w+$"
   default_url: https://www.ncbi.nlm.nih.gov/nuccore/[%s]
 
-- db_prefix: RCSB_PDB
-  name: RCSB_PDB
-  example_gid: RCSB_PDB:1GZP
-  gid_pattern: "RCSB_PDB:\\w+$"
-  default_url: https://www.rcsb.org/structure/[%s]
-
 - db_prefix: SO
   name: Sequence Ontology
   example_gid: SO:0001217

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -456,7 +456,7 @@
   name: NCI Thesaurus
   aliases: ['NCI_Thesaurus', 'NCI']
   example_gid: NCI:C7646
-  gid_pattern: "^NCI:C\d+$"
+  gid_pattern: "^NCI:C\\d+$"
   default_url : https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=[%s]
 
 - db_prefix: OMIM

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -417,7 +417,7 @@
 - db_prefix: KEGG
   name: Kyoto Encyclopedia of Genes and Genomes
   example_id: KEGG:05220
-  gid_pattern: "^KEGG:\\d+$"
+  gid_pattern: "^KEGG:\\w*:*\\d+$"
   default_url: http://www.genome.jp/dbget-bin/www_bget?map[%s]
 
 - db_prefix: MESH

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -518,7 +518,7 @@
 - db_prefix: RCSB_PDB
   name: RCSB_PDB
   example_gid: RCSB_PDB:1GZP
-  gid_pattern: ""RCSB_PDB:\\w+$""
+  gid_pattern: "RCSB_PDB:\\w+$"
   default_url: https://www.rcsb.org/structure/[%s]
 
 - db_prefix: SO

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -479,7 +479,7 @@
 # maybe make this an alias of Orphanet instead.
 - db_prefix: ORDO
   name: ORDO
-  example_id: ORDO:600483
+  example_id: ORDO:600483, ORDO:644:GARD:262
   gid_pattern: "^ORDO:\\d+:*[GARD]*:*\\d*$"
   default_url:  https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=EN&Expert=[%s]
     

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -500,7 +500,7 @@
     - name: ZFIN
       url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=ZFIN=[%s]
     - name: WB
-      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=WB=[%s]
+      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=WormBase=[%s]
     - name: HGNC
       url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=[%ss]&species=agr&seq=HGNC=[%s]
     - name: SGD

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -416,14 +416,14 @@
 
 - db_prefix: KEGG
   name: Kyoto Encyclopedia of Genes and Genomes
-  example_id: NoideaNeed TolLookOneUp
-  gid_pattern: NoneAtMoment
+  example_id: KEGG:05220
+  gid_pattern: "^KEGG:\\d+$""
   default_url: http://www.genome.jp/dbget-bin/www_bget?map[%s]
 
 - db_prefix: MESH
   name: Medical Subject Headings
   example_gid: MESH:D020516
-  gid_pattern: "^MESH:D\\d+$"
+  gid_pattern: "^MESH:[CD]+\\d+$"
   default_url: https://www.ncbi.nlm.nih.gov/mesh/[%s]
 
 - db_prefix: MINT

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -74,6 +74,7 @@
     - taxon: "10116"
     - taxon_str: NCBITaxon:10116
     - abbreviation: Rno
+    - species_name: Rattus norvegicus
   example_gid: RGD:1311419
   gid_pattern: "^RGD:\\d+$"
   default_url: https://rgd.mcw.edu/rgdweb/elasticResults.html?term=RGD:[%s]

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -515,10 +515,8 @@
   gid_pattern: "^RefSeq:\\w+$"
   default_url: https://www.ncbi.nlm.nih.gov/nuccore/[%s]
 
-# Could not find entries in WWPDB so use RCSB_PDB
 - db_prefix: RCSB_PDB
   name: RCSB_PDB
-  aliases: ['WWPDB']
   example_gid: RCSB_PDB:1GZP
   gid_pattern: ""RCSB_PDB:\\w+$""
   default_url: https://www.rcsb.org/structure/[%s]

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -379,6 +379,8 @@
       url: https://www.ncbi.nlm.nih.gov/gds/?term=[%s]
     - name: htp/datasetsample
       url: https://www.ncbi.nlm.nih.gov/gds/?term=[%s]
+    - name: entrezgene
+      url: https://www.ncbi.nlm.nih.gov/sites/entrez?Db=geoprofiles&DbFrom=gene&Cmd=Link&LinkName=gene_geoprofiles&LinkReadableName=GEO%20Profiles&IdsFromResult=[%s]
 
 - db_prefix: GXA
   name: ExpressionAtlas

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -145,7 +145,7 @@
   name: FlyBase
   example_gid: FB:FBgn0000490
   gid_pattern: "^FB:FB.+$"
-  default_url: 
+  default_url: https://flybase.org/reports/[%s]
   pages:
     - name: gene
       url: https://flybase.org/reports/[%s].html

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -151,6 +151,8 @@
       url: https://flybase.org/reports/[%s].html
     - name: gene/expression
       url: https://flybase.org/reports/[%s].html#expression
+    - name: gene/expression_images
+      url: https://flybase.org/reports/[%s].html#expression
     - name: gene/references
       url: https://flybase.org/reports/[%s].html#pubs
     - name: gene/phenotypes

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -60,11 +60,6 @@
 
 - db_prefix: RGD
   name: RGD
-  aliases: 
-    - taxon: "10116"
-    - taxon_str: NCBITaxon:10116
-    - abbreviation: Rno
-    - species_name: Rattus norvegicus
   example_gid: RGD:1311419
   gid_pattern: "^RGD:\\d+$"
   default_url: https://rgd.mcw.edu/rgdweb/elasticResults.html?term=RGD:[%s]
@@ -91,6 +86,8 @@
       url: https://rgd.mcw.edu/rgdweb/report/reference/main.html?id=RGD:[%s]
     - name: strain
       url: https://rgd.mcw.edu/rgdweb/report/strain/main.html?id=[%s]
+    - name: pub
+      url: http://rgd.mcw.edu/rgdweb/search/search.html?term=[%s]
 
 #
 # ZFIN
@@ -215,7 +212,8 @@
       url: http://www.wormbase.org/db/get?name=[%s];class=Gene;widget=interactions
     - name: construct
       url: https://www.wormbase.org/db/get?name=[%s];class=Construct
-
+    - name: pub
+      url: http://www.wormbase.org/db/misc/paper?name=[%s]
 #
 # SGD
 #
@@ -244,7 +242,8 @@
     url: https://www.yeastgenome.org/locus/[%s]/interaction#network
   - name: htp/dataset
     url: https://www.yeastgenome.org/dataset/[%s]
-
+  - name: reference
+    url: https://www.yeastgenome.org/reference/[%s]
 #
 # GO
 #
@@ -490,6 +489,7 @@
 
 - db_prefix: PMID
   name: PubMed
+  aliases: ['pubmed', 'BOB']
   example_gid: PMID:26447131
   gid_pattern: "^PMID:\\d+$"
   default_url: https://www.ncbi.nlm.nih.gov/pubmed/[%s]

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -402,8 +402,8 @@
 
 - db_prefix: KEGG
   name: Kyoto Encyclopedia of Genes and Genomes
-  example_id: ?
-  gid_pattern: None?
+  example_id: NoideaNeed TolLookOneUp
+  gid_pattern: NoneAtMoment
   default_url: http://www.genome.jp/dbget-bin/www_bget?map[%s]
 
 - db_prefix: MESH

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -311,7 +311,7 @@
   name: DOI
   example_gid: DOI:10.3389/fcimb.2016.00052
   gid_pattern: "^DOI:\\S+$"
-  default_url: doi.org/[%s]
+  default_url: https://doi.org/[%s]
 
 - db_prefix: DOID
   name: Disease Ontology

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -417,7 +417,7 @@
 - db_prefix: KEGG
   name: Kyoto Encyclopedia of Genes and Genomes
   example_id: KEGG:05220
-  gid_pattern: "^KEGG:\\d+$""
+  gid_pattern: "^KEGG:\\d+$"
   default_url: http://www.genome.jp/dbget-bin/www_bget?map[%s]
 
 - db_prefix: MESH

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -394,7 +394,7 @@
   name: IntAct Molecular Interaction Database
   example_id: INTACT:EBI-1000008
   gid_pattern: "^INTACT:EBI\\-[0-9]+$"
-  default_url: https://www.ebi.ac.uk/intact/pages/details/details.xhtml?interactionAc=[%s]
+  default_url: https://www.ebi.ac.uk/intact/interaction/[%s]
   pages:
     - name: gene/interactions
       url: https://www.ebi.ac.uk/intact/pages/details/details.xhtml?interactionAc=[%s]
@@ -514,6 +514,14 @@
   example_gid: RefSeq:NT_033778
   gid_pattern: "^RefSeq:\\w+$"
   default_url: https://www.ncbi.nlm.nih.gov/nuccore/[%s]
+
+# Could not find entries in WWPDB so use RCSB_PDB
+- db_prefix: RCSB_PDB
+  name: RCSB_PDB
+  aliases: ['WWPDB']
+  example_gid: RCSB_PDB:1GZP
+  gid_pattern: ""RCSB_PDB:\\w+$""
+  default_url: https://www.rcsb.org/structure/[%s]
 
 - db_prefix: SO
   name: Sequence Ontology


### PR DESCRIPTION
Firstly I apologise if the diffs are too big but I found it very hard to find what DB's are in there and find them, so apart from the major ones I sorted them alphabetically to make finding them easier.

New Databases have been added with url ( of the top of my head):
   MESH, KEGG, GARD

We have 2 new dict keys:
   aliases: which takes an array of alternative keys, a good example here is Orphanet where I added 'ORPHA' as an alias to help lookups.

  ignore_url_generation: if set this is telling the loader not to generate urls for that DB. Example here is UMLS_CUI

Added special panther pages which are the DB's

i.e.
pages:
    - name: MGI
      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=PAN_BOOK&species=agr&seq=MGI=MGI=[%s]
    - name: FB
      url:  http://pantherdb.org/treeViewer/treeViewer.jsp?book=PAN_BOOK&species=agr&seq=FlyBase=[%s]

NOTE: PANBOOK is replace by the panther id in the url generation.

I think that is all of it...

