### PR TITLE
Fix incorrect URL constructor for WB gene phenotypes

### DIFF
--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -205,7 +205,7 @@
     - name: gene/references
       url: https://www.wormbase.org/db/get?name=[%s];class=Gene;widget=references
     - name: gene/phenotypes
-      url: http://www.wormbase.org/db/get?name=[%s];class=Gene;widget=phenotypes
+      url: https://www.wormbase.org/db/get?name=[%s];class=Gene;widget=phenotype
     - name: gene/spell
       url: http://spell.wormbase.org/search/show_results?search_string=[%s]
     - name: gene/expression/annotation/detail


### PR DESCRIPTION
@sierra-moxon 
While testing stage I realized that our gene phenotype linkouts to WormBase had the wrong URL constructor so I changed it from:

http://www.wormbase.org/db/get?name=[%s];class=Gene;widget=phenotypes

to:

https://www.wormbase.org/db/get?name=[%s];class=Gene;widget=phenotype

which should now work