### PR TITLE
add back publicationRef.json

### DIFF
--- a/ingest/publicationRef.json
+++ b/ingest/publicationRef.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Publication reference",
+  "description": "An basic entry for defining a ref to a publication",
+  "id": "publicationRef.json#",
+  "type": "object",
+  "required": ["publicationId"],
+  "properties": {
+    "publicationId": {
+      "$ref" : "globalId.json#/properties/globalId",
+      "description": "The ID from the data provider that describes the publication.  When available, this is the PMID. When no PMID (PUBMED id) is available, this is the MOD publication id."
+    },
+    "crossReference": {
+      "description": "an optional cross reference to the MOD publication page.",
+      "$ref" : "crossReference.json#"
+    }
+  }
+}


### PR DESCRIPTION
The publicationRef.json seems to have disappeared (in release-1.0.1.3 and master branches) - possibly in commit 6dc325792b5b16e3008213afdfb2e5acee9d4118?

As such, the agr_validate.py script is giving a FileNotFoundError, and failing to validate files (and thus preventing file uploads).