### PR TITLE
Literature tweaks

### DIFF
--- a/ingest/resourcesAndReferences/authorReference.json
+++ b/ingest/resourcesAndReferences/authorReference.json
@@ -33,6 +33,9 @@
       "$ref":"../globalId.json#/properties/globalId",
       "description": "The globally unique identifier for the resource.  ie: NLMId or ISBN or MOD ID.  Each identifier should be prefixed and of the form prefix:id "
     },
+    "authorRank": {
+      "type": "number"
+    },
     "crossReferences":{
       "$ref": "../crossReference.json"
     }

--- a/ingest/resourcesAndReferences/reference.json
+++ b/ingest/resourcesAndReferences/reference.json
@@ -20,6 +20,9 @@
     "title": {
       "type": "string"
     },
+    "language": {
+      "type": "string"
+    },
     "authors": {
       "type": "array",
       "items": {

--- a/ingest/resourcesAndReferences/resource.json
+++ b/ingest/resourcesAndReferences/resource.json
@@ -38,6 +38,9 @@
     "medlineAbbreviation": {
       "type": "string"
     },
+    "language": {
+      "type": "string"
+    },
     "copyrightDate": {
       "type": "string",
       "format": "date-time"

--- a/ingest/resourcesAndReferences/resource.json
+++ b/ingest/resourcesAndReferences/resource.json
@@ -38,9 +38,6 @@
     "medlineAbbreviation": {
       "type": "string"
     },
-    "language": {
-      "type": "string"
-    },
     "copyrightDate": {
       "type": "string",
       "format": "date-time"

--- a/ingest/resourcesAndReferences/resource.json
+++ b/ingest/resourcesAndReferences/resource.json
@@ -6,9 +6,7 @@
   "type": "object",
   "required": [
     "primaryId",
-    "title",
-    "isoAbbreviation",
-    "medlineAbbreviation"
+    "title"
   ],
   "additionalProperties": false,
   "properties": {
@@ -21,6 +19,13 @@
       "description": "The title of the resource."
     },
     "titleSynonyms":  {
+      "type" : "array",
+        "items": {
+          "type": "string"
+        },
+      "uniqueItems": true
+    },
+    "abbreviationSynonyms":  {
       "type" : "array",
         "items": {
           "type": "string"
@@ -59,7 +64,7 @@
       }
     },
     "pages": {
-      "type": "number"
+      "type": "string"
     },
     "abstractOrSummary": {
       "type": "string"


### PR DESCRIPTION
Suggested changes based on the limitations of FB data for resources, or, additional input from curators:
1. Resources:
  a. Make iso and medline abbreviations optional, since not all FB resources have such abbreviations.
  b. Add abbreviationSynonyms, since journal abbreviations at FB are an unknown mix of iso and medline.
  c. For pages, expect string, not number, consistent with FB data and in line with reference "pages" attribute.
  d. Add language attribute. 
2. References:
  a. Add language attribute.
3. Authors:
  a. Add authorRank to preserve order of authorship.