### PR TITLE
fix biolinkml version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ strict_rfc3339>=0.0
 jsonschema==2.5.1
 pyyaml==5.1
 simplejson
-biolinkml>=1.5.10
+biolinkml>=1.3.8


### PR DESCRIPTION
A couple of PRs are failing Travis now due to an issue with the version of biolinkml specified in the requirements.txt file. I changed this to the version suggested by pip.