### PR TITLE
Travis test without biolinkml in requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - "python bin/agr_validate.py -s ingest/htp/datasetSample/datasetSampleMetaDataDefinition.json -d ingest/htp/datasetSample/exampleSGDdatasample.json"
   - "python bin/agr_validate.py -s ingest/htp/dataset/datasetMetaDataDefinition.json -d ingest/htp/dataset/exampleDataset.json"
   - "python bin/agr_validate.py -s ingest/htp/dataset/datasetMetaDataDefinition.json -d ingest/htp/dataset/exampleSuperseriesDataset.json"
-  - "python bin/agr_validate.py -s ingest/molecules/moleculeMetadData.json -d ingest/molecules/WbSampleMolecule.json"
+  - "python bin/agr_validate.py -s ingest/molecules/moleculeMetaData.json -d ingest/molecules/WbSampleMolecule.json"
   - "python bin/validate_yaml.py"
 
 # whitelist

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ strict_rfc3339>=0.0
 jsonschema==2.5.1
 pyyaml==5.1
 simplejson
-biolinkml>=1.5.10
+biolinkml>=1.3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ strict_rfc3339>=0.0
 jsonschema==2.5.1
 pyyaml==5.1
 simplejson
-biolinkml>=1.3.8
+#biolinkml>=1.3.8


### PR DESCRIPTION
Removing biolinkml in requirements because that requires python3.7 (and we're on 3.5). This, plus a small fix in the travis yml, makes Travis happy. If we actually need biolinkml module now, then please ignore this PR - but if that's true, might be time to update to python 3.7?