### PR TITLE
Begin aligning with Bioregistry and add validation

### DIFF
--- a/bin/bioregistry_validate.py
+++ b/bin/bioregistry_validate.py
@@ -1,0 +1,24 @@
+"""Test that all prefixes are alignable with the Bioregistry."""
+
+import unittest
+from pathlib import Path
+
+import bioregistry
+import yaml
+
+HERE = Path(__file__).parent.resolve()
+ROOT = HERE.parent.resolve()
+PATH = ROOT.joinpath("resourceDescriptors.yaml")
+
+
+class TestIntegrity(unittest.TestCase):
+    def setUp(self) -> None:
+        self.entries = yaml.safe_load(PATH.read_text())
+
+    def test_prefixes(self):
+        for entry in self.entries:
+            prefix = entry["db_prefix"]
+            with self.subTest(prefix=prefix):
+                self.assertIsNotNone(bioregistry.normalize_prefix(prefix), msg=f"Prefix {prefix} is not in bioregistry")
+                for alias in entry.get("aliases", []):
+                    self.assertIsNotNone(bioregistry.normalize_prefix(alias), msg=f"Unknown alias {alias} for prefix {prefix}")


### PR DESCRIPTION
This PR adds a script that validates all of the entries in `resourceDescriptors.yaml` are alignable (though not necessarily standardized) with the Bioregistry. This motivated some improvements to the Bioregistry itself in https://github.com/biopragmatics/bioregistry/commit/486cdd409a38e8803aabd92686c40132420b6b23, but also pointed out several more general issues with the ARG resources described in the following issues (which should all be sorted out before really considering this PR):

- [x] #281 
- [x] #282 
- [x] #283 
- [x] #284 
- [x] #285