### PR TITLE
SCRUM-1884 filegen xenbase onboarding

### DIFF
--- a/ingest/affectedGenomicModel/affectedGenomicModel.json
+++ b/ingest/affectedGenomicModel/affectedGenomicModel.json
@@ -30,39 +30,39 @@
     "synonyms": {
       "type": "array",
       "items": {
-         "type": "string"
+        "type": "string"
       },
-    "uniqueItems": true
+      "uniqueItems": true
     },
     "secondaryIds":{
       "type": "array",
       "items": {
-         "type": "string"
+        "type": "string"
       },
-    "uniqueItems": true
+      "uniqueItems": true
     },
     "affectedGenomicModelComponents": {
       "description": "Collection of genomic components that make up a model, ie: 'allele', each with a zygosity",
-       "type": "array",
-       "items": {
-         "$ref" : "affectedGenomicModelComponent.json#"
-       },
+      "type": "array",
+      "items": {
+        "$ref" : "affectedGenomicModelComponent.json#"
+      },
       "uniqueItems": true
     },
     "sequenceTargetingReagentIDs": {
       "description": "Collection of sequence targeting reagent components that make up a genotype.",
-       "type": "array",
-       "items": {
-         "$ref" : "../globalId.json#/properties/globalId"
-       },
+      "type": "array",
+      "items": {
+        "$ref" : "../globalId.json#/properties/globalId"
+      },
       "uniqueItems": true
     },
     "parentalPopulationIDs": { "description": "Collection of background components that make up a genotype.",
-       "type": "array",
-       "items": {
-         "$ref" : "../globalId.json#/properties/globalId"
-       },
+      "type": "array",
+      "items": {
+        "$ref" : "../globalId.json#/properties/globalId"
+      },
       "uniqueItems": true
-     }
+    }
   }
 }

--- a/ingest/phenotype/phenotypeModelAnnotation.json
+++ b/ingest/phenotype/phenotypeModelAnnotation.json
@@ -16,22 +16,23 @@
       "$ref" : "../globalId.json#/properties/globalId",
       "description" : "The ID to which the phenotype ontology term(s) is applied. For this submission, these will be genes and single affected gene alleles."
     },
- "primaryGeneticEntityIDs": {
-"type": "array",
+    "primaryGeneticEntityIDs": {
+      "type": "array",
       "items": {
         "$ref" : "../globalId.json#/properties/globalId",
-       "description": "for calculated submissions, this field represents the id of the genetic objects (allele or affectedGenomicModel) that this annotation is based on."}
-   },
+        "description": "for calculated submissions, this field represents the id of the genetic objects (allele or affectedGenomicModel) that this annotation is based on."
+      }
+    },
     "phenotypeTermIdentifiers": {
-     "type": "array",
-     "items": {
-     	      "$ref" : "phenotypeTermIdentifier.json#"
-     },
-     "description":"For most MODs, this will be a single term identifying the phenotype annotation.  For ZFIN, this will be a list, representing a post-composed phenotype annotation."
+      "type": "array",
+      "items": {
+        "$ref" : "phenotypeTermIdentifier.json#"
+      },
+      "description":"For most MODs, this will be a single term identifying the phenotype annotation.  For ZFIN, this will be a list, representing a post-composed phenotype annotation."
     },
     "phenotypeStatement": {
-     "type": "string",
-     "description": "use to provide a human-readable text display for the combination of 1->many ontology terms coded in the phenotypeTermIdentifiers collection."
+      "type": "string",
+      "description": "use to provide a human-readable text display for the combination of 1->many ontology terms coded in the phenotypeTermIdentifiers collection."
     },
     "evidence": {
       "$ref": "../publicationRef.json#",

--- a/ingest/phenotype/phenotypeTermIdentifier.json
+++ b/ingest/phenotype/phenotypeTermIdentifier.json
@@ -8,11 +8,11 @@
   "additionalProperties": false,
   "properties": {
     "termId": {
-    	    "$ref": "../globalId.json#/properties/globalId",
+      "$ref": "../globalId.json#/properties/globalId",
 	    "description":"the id that represents a part, or the entire, phenotype statement - an ontology id."    
     },
     "termOrder": {
-    	      "type":"integer"
+      "type":"integer"
     }
   }
 }

--- a/ingest/species/species.yaml
+++ b/ingest/species/species.yaml
@@ -10,6 +10,7 @@
    dataProviderFullName: Zebrafish Information Network
    dataProviderShortName: ZFIN
   phylogenicOrder: 40
+  fmsSubtypeName: ZFIN
 
 - taxonId: NCBITaxon:2697049
   shortName: SARS-CoV-2
@@ -32,6 +33,7 @@
    dataProviderFullName: Alliance of Genome Resources
    dataProviderShortName: Alliance
   phylogenicOrder: 80
+  fmsSubtypeName: SARS-CoV-2
 
 - taxonId: NCBITaxon:7227
   shortName: Dme
@@ -44,6 +46,7 @@
    dataProviderFullName: FlyBase
    dataProviderShortName: FB
   phylogenicOrder: 50
+  fmsSubtypeName: FB
 
 - taxonId: NCBITaxon:6239
   shortName: Cel
@@ -55,6 +58,7 @@
    dataProviderFullName: WormBase
    dataProviderShortName: WB 
   phylogenicOrder: 60
+  fmsSubtypeName: WB
 
 - taxonId: NCBITaxon:10116
   shortName: Rno
@@ -66,6 +70,7 @@
    dataProviderFullName: Rat Genome Database
    dataProviderShortName: RGD
   phylogenicOrder: 20
+  fmsSubtypeName: RGD
    
 - taxonId: NCBITaxon:10090
   shortName: Mmu 
@@ -77,6 +82,7 @@
    dataProviderFullName: Mouse Genome Informatics
    dataProviderShortName: MGI
   phylogenicOrder: 30
+  fmsSubtypeName: MGI
 
 - taxonId: NCBITaxon:559292
   shortName: Sce
@@ -88,6 +94,7 @@
    dataProviderFullName: Saccharomyces Genome Database
    dataProviderShortName: SGD
   phylogenicOrder: 70
+  fmsSubtypeName: SGD
 
 # NOTE: Hsa uses RGD for now,
 - taxonId: NCBITaxon:9606
@@ -100,6 +107,7 @@
    dataProviderFullName: Rat Genome Database
    dataProviderShortName: RGD
   phylogenicOrder: 10
+  fmsSubtypeName: HUMAN
 
 - taxonId: NCBITaxon:8355
   shortName: Xla
@@ -111,6 +119,7 @@
    dataProviderFullName: Xenbase
    dataProviderShortName: XB
   phylogenicOrder: 46
+  fmsSubtypeName: XBXL
 
 - taxonId: NCBITaxon:8364
   shortName: Xtr
@@ -122,4 +131,5 @@
     dataProviderFullName: Xenbase
     dataProviderShortName: XB
   phylogenicOrder: 45
+  fmsSubtypeName: XBXT
   


### PR DESCRIPTION
I added a `fmsSubtypeName` for all species in the species.yaml, such that it can be retrieved from the file generator (and the loader) to link taxonomy IDs to FMS subtypes (rather than using a hardcoded list in the file generated). The value equals that of `primaryDataProvider.dataProviderShortName` for most, except `HUMAN` and the two xenbase species (`XBXT` and `XBXL`).