### PR TITLE
Corrected common name of X. tropicalis

### DIFF
--- a/ingest/species/species.yaml
+++ b/ingest/species/species.yaml
@@ -125,7 +125,7 @@
   shortName: Xtr
   fullName: Xenopus tropicalis
   commonNames:
-    - African clawed frog
+    - Western clawed frog
     - xbxt
   primaryDataProvider: 
     dataProviderFullName: Xenbase


### PR DESCRIPTION
... from "African Clawed Frog" to "Western Clawed Frog"