### PR TITLE
Add-scRNA-seq-MMO-term-to-assay-types

### DIFF
--- a/ingest/htp/datasetSample/datasetSampleAnnotation.json
+++ b/ingest/htp/datasetSample/datasetSampleAnnotation.json
@@ -50,7 +50,7 @@
         },
         "assayType": {
             "$ref": "../../globalId.json#/properties/globalId",
-            "enum": ["MMO:0000659", "MMO:0000648","MMO:0000650","MMO:0000649","MMO:0000664","MMO:0000666","MMO:0000000"],
+            "enum": ["MMO:0000659", "MMO:0000648","MMO:0000650","MMO:0000649","MMO:0000664","MMO:0000666","MMO:0000000","MMO:0000862"],
             "description": "id of type of assay used for this sample; sample or experiment property?"
         },
         "sequencingFormat": {


### PR DESCRIPTION
MMO:0000862 added to enum for HTP assay types

@oblodgett @sierra-moxon @christabone 
The Expression working group needs to add "single-cell RNA-seq" as an assay type for HTPDATASET submissions. I'm pretty sure this is the only change in this repo needed, but I don't know what the downstream consequences are and I know that we've generally frozen this schema and prefer not to touch it. I'm wondering if this small enum addition can go through with little to no hassle?