### PR TITLE
KANBAN-553: Update resourceDescriptors.yaml

### DIFF
--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -536,10 +536,10 @@
   name: HGNC
   example_gid: HGNC:33510
   gid_pattern: "^HGNC:\\d+$"
-  default_url: http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:[%s]
+  default_url: https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:[%s]
   pages:
     - name: gene
-      url: http://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:[%s]
+      url: https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:[%s]
     - name: gene/MODinteractions
       url: https://rgd.mcw.edu/rgdweb/cytoscape/cy.html?species=1&identifiers=HGNC:[%s]
     - name: gene/MODinteractions_genetic

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -536,10 +536,10 @@
   name: HGNC
   example_gid: HGNC:33510
   gid_pattern: "^HGNC:\\d+$"
-  default_url: https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:[%s]
+  default_url: https://bioregistry.io/hgnc:[%s]
   pages:
     - name: gene
-      url: https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:[%s]
+      url: https://bioregistry.io/hgnc:[%s]
     - name: gene/MODinteractions
       url: https://rgd.mcw.edu/rgdweb/cytoscape/cy.html?species=1&identifiers=HGNC:[%s]
     - name: gene/MODinteractions_genetic


### PR DESCRIPTION
For HGNC resource descriptors entry:
update http to https
update URL pattern to 
https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:[%s]