### PR TITLE
Update resource descriptor file for OMIM to MIM change

### DIFF
--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -689,7 +689,7 @@
 
 - db_prefix: MIM
   name: MIM
-  aliases: ['mim']
+  aliases: ['mim', 'omim']
   example_id: MIM:600483, MIM:PS203655
   gid_pattern: "^(MIM|mim):[PS]*\\d+$"
   default_url: https://www.omim.org/entry/[%s]

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -690,7 +690,7 @@
 - db_prefix: MIM
   name: MIM
   aliases: ['mim']
-  example_id: MIM:600483, MIM:PS100200
+  example_id: MIM:600483, MIM:PS203655
   gid_pattern: "^(MIM|mim):[PS]*\\d+$"
   default_url: https://www.omim.org/entry/[%s]
   pages:

--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -687,11 +687,11 @@
     - name: pub
       url: https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=[%s]
 
-- db_prefix: OMIM
-  name: OMIM
-  aliases: ['omim']
-  example_id: OMIM:600483, OMIM:PS100200
-  gid_pattern: "^(OMIM|omim):[PS]*\\d+$"
+- db_prefix: MIM
+  name: MIM
+  aliases: ['mim']
+  example_id: MIM:600483, MIM:PS100200
+  gid_pattern: "^(MIM|mim):[PS]*\\d+$"
   default_url: https://www.omim.org/entry/[%s]
   pages:
     - name: homepage


### PR DESCRIPTION
I've updated the OMIM stanza in the resource descriptors YAML file to accommodate the change in curie prefix from "OMIM" to "MIM". I think I made the changes that are needed, but please have a look to check.