### PR TITLE
Update MIM resource descriptors

### DIFF
--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -697,13 +697,13 @@
     - name: homepage
       url: https://www.omim.org/
     - name: gene
-      url: https://www.omim.org/entry/[%s]
+      url: https://www.omim.org/[%s]
     - name: gene/interactions
-      url: https://www.omim.org/entry/[%s]
+      url: https://www.omim.org/[%s]
     - name: disease
-      url: https://www.omim.org/entry/[%s]
+      url: https://www.omim.org//[%s]
     - name: ont
-      url: https://www.omim.org/phenotypicSeries/[%s]
+      url: https://www.omim.org/[%s]
 
 - db_prefix: ORCID
   name: ORCID


### PR DESCRIPTION
@christabone  I've made some more changes to the MIM prefix stanza in the resource descriptors YAML to accommodate a link change at OMIM.

@sbello had pointed out that to link to OMIM with MIM IDs or MIM:PS IDs (for phenotypic series) we can simply use one linking paradigm:

https://www.omim.org/[%s]

but this will only work properly if the replacement for [%s] is the entire curie/ID including the prefix, so:

https://www.omim.org/MIM:600483

will resolve to:

https://www.omim.org/entry/600483

and this:

https://www.omim.org/MIM:PS203655

will resolve to:

https://www.omim.org/phenotypicSeries/PS203655

but:

https://www.omim.org/600483

and

https://www.omim.org/PS203655

will not resolve to anything meaningful. @oblodgett suggested that in order to properly accommodate this change, there probably need to be loader changes as well.
