### PR TITLE
SCRUM-4158: Add SGD disease page to resourceDescriptors.yaml

### DIFF
--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -447,6 +447,8 @@
       url: https://www.wormbase.org/resources/disease/[%s]
     - name: disease/fb
       url: https://flybase.org/cgi-bin/cvreport.html?id=[%s]
+    - name: disease/sgd
+      url: https://www.yeastgenome.org/disease/[%s]
 
 - db_prefix: DRSC
   name: DRSC


### PR DESCRIPTION
Here's the linked ticket:

https://agr-jira.atlassian.net/browse/SCRUM-4158

page_area field for "DOID" data provider cross references on disease annotations should be submitted for SGD as "disease/sgd"