### PR TITLE
SCRUM-2086 Update UMLS URL constructor

### DIFF
--- a/resourceDescriptors.yaml
+++ b/resourceDescriptors.yaml
@@ -886,10 +886,10 @@
     name: UMLS_CUI
     example_gid: UMLS_CUI:C0011127
     gid_pattern: "^UMLS_CUI:C\\d+$"
-    default_url: https://uts.nlm.nih.gov/uts/umls/searchResults?searchString=[%s]
+    default_url: 	https://identifiers.org/umls:[%s]
     pages:
       - name: ontology_provided_cross_reference
-        url: https://uts.nlm.nih.gov/uts/umls/searchResults?searchString=[%s]
+        url: https://identifiers.org/umls:[%s]
 
   - db_prefix: UniProtKB
     name: UniProtKB


### PR DESCRIPTION
For ticket SCRUM-2086:

I've replaced the existing URL pattern (which leads to a login page) with the pattern described at identifiers.org

https://registry.identifiers.org/registry/umls